### PR TITLE
Emit the library object instead of the name

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -108,8 +108,7 @@ export class Sync {
 
     // update all libraries
     for (const [n, [prefix, library]] of enumerate(this.libraries)) {
-      const name = library.type === 'group' ? library.name : undefined
-      this.emitter.emit(Sync.event.library, name, n + 1, libraries.length)
+      this.emitter.emit(Sync.event.library, library, n + 1, libraries.length)
 
       try {
         await this.update(store, prefix)


### PR DESCRIPTION
What about this: let the event handler decide how to handle the missing name problem - this way we don't have to worry about it anymore and the event handler has full access to the library object's properties. #

This might also make sense for the other event emitters, too, so that the handlers would know about the item or collection that is currently being processed. What do you think?