### PR TITLE
Add the "type" property to the Library interface

### DIFF
--- a/typings/zotero.ejs
+++ b/typings/zotero.ejs
@@ -38,6 +38,7 @@ export declare namespace Zotero {
   interface Library {
     version: number
     name: string
+    type: string
     save: (name: string, version: number) => Promise<void>
     remove_collections: (keys: string[]) => Promise<void>
     add_collection: (collection: Collection) => Promise<void>


### PR DESCRIPTION
otherwise I get an error when trying to query it. 