### PR TITLE
Fix mismatch of group list between /keys/current and /users/x/groups

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -55,11 +55,13 @@ export class Sync {
     }
 
     for (const library of await this.json(`https://api.zotero.org/users/${account.userID}/groups`)) {
-      const prefix = `/groups/${library.id}`
-      this.libraries[prefix] = {
-        type: 'group',
-        prefix,
-        name: library.data.name,
+      if (account.access.groups[library.id]) {
+        const prefix = `/groups/${library.id}`
+        this.libraries[prefix] = {
+          type: 'group',
+          prefix,
+          name: library.data.name,
+        }
       }
     }
 

--- a/package.json
+++ b/package.json
@@ -14,6 +14,10 @@
   "typings": "./typings/zotero.d.ts",
   "author": "Emiliano Heyns",
   "license": "AGPL",
+  "keywords": [
+    "zotero",
+    "zotero-sync"
+  ],
   "devDependencies": {
     "@types/node": "^14.14.41",
     "ejs": "^3.1.6",


### PR DESCRIPTION
`/users/x/groups` lists groups to which the current key has no access. the definitive list of accessible groups is retrieved from `/keys/current`. This change  removes inaccessible groups from the libraries list.