### PR TITLE
Fix collections data interface to reflect the actual data

### DIFF
--- a/typings/zotero.ejs
+++ b/typings/zotero.ejs
@@ -15,24 +15,9 @@ export declare namespace Zotero {
   interface Collection {
     key: string;
     version: number;
-    library: {
-      type: string;
-      id: number;
-      name: string;
-      links: Record<'self' | 'alternate' | 'up', { href: string, type: string }>
-    }
-    links: Record<'self' | 'alternate' | 'up', { href: string, type: string }>
-    meta: {
-      numCollections: number;
-      numItems: number;
-    }
-    data: {
-      key: string;
-      version: number;
-      name: string;
-      parentCollection: false | string;
-      relations: Record<'owl:sameAs' | 'dc:replaces' | 'dc:relation', string>
-    }
+    name: string;
+    parentCollection: false | string;
+    relations: Record<'owl:sameAs' | 'dc:replaces' | 'dc:relation', string>
   }
 
   interface Library {


### PR DESCRIPTION
I am not 100% this is correct, but it seems to me that the collection interface should not model the raw json data returned **from** a request to the Zotero server (including the metadata wrapper), but the actual collection data that is submitted `**to** the server when POSTing it. Can you check?